### PR TITLE
Adjuste SLS cis-benchmark.enforce : osmajorrelease grain as an integer

### DIFF
--- a/cis-benchmark/enforce.sls
+++ b/cis-benchmark/enforce.sls
@@ -3,10 +3,10 @@
 
 {% from "cis-benchmark/map.jinja" import cis_benchmark with context %}
 
-{% if salt['grains.item']('os') == 'CentOS' %}
+{% if grains['os'] == 'CentOS' %}
 
 # CentOS
-{% if salt['grains.item']('osmajorrelease') == '7' %}
+{% if grains['osmajorrelease']|int == 7 %}
 include:
   - cis-benchmark.centos7.enforce
 {% endif %}


### PR DESCRIPTION
https://docs.saltstack.com/en/latest/topics/releases/2017.7.0.html#grains-changes

The osmajorrelease grain has been changed from a string to an integer. State files, especially those using a templating language like Jinja, may need to be adjusted to account for this change.